### PR TITLE
fix: Set backend-v1 Service targetPort to 8080 to match pod containerPort

### DIFF
--- a/backend-v1.yaml
+++ b/backend-v1.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 8080
     protocol: TCP
-    targetPort: 8081
+    targetPort: 8080
   selector:
     app: backend
     version: v1


### PR DESCRIPTION
This pull request fixes the issue where backend-v1 Service's targetPort was incorrectly set to 8081, while backend pods listen on port 8080. Updating to 8080 resolves connection reset errors from frontend to backend-v1 and restores connectivity.

Steps:
- Modified backend-v1.yaml to set targetPort 8080
- Tested in cluster, connectivity verified

Please review and merge to restore correct service routing.