### PR TITLE
fix: Correct backend-v1 Service targetPort to 8080 to match container port

### DIFF
--- a/backend-v1.yaml
+++ b/backend-v1.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 8080
     protocol: TCP
-    targetPort: 8081
+    targetPort: 8080
   selector:
     app: backend
     version: v1


### PR DESCRIPTION
This PR fixes the backend-v1 Service manifest by changing targetPort from 8081 to 8080 to match the backend pod containerPort. This will resolve the connection refused errors seen by frontend accessing backend-v1 service.